### PR TITLE
Enhancement - Additional read-only properties

### DIFF
--- a/source/IPAddressControl.cs
+++ b/source/IPAddressControl.cs
@@ -256,6 +256,37 @@ namespace IPAddressControlLib
       }
     }
 
+    [Browsable(false),
+     EditorBrowsable(EditorBrowsableState.Advanced),
+     DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionStart
+    {
+      get
+      {
+        var position = 0;
+        for (int i = 0; i < _fieldControls.Length; i++)
+        {
+          // Allow for the dots
+          if (i > 0)
+          {
+            position++;
+          }
+
+          var fieldControl = _fieldControls[i];
+          if (fieldControl.Focused)
+          {
+            return position + fieldControl.SelectionStart;
+          }
+          else
+          {
+            position += fieldControl.Text.Length;
+          }
+        }
+
+        return 0;
+      }
+    }
+
     [Bindable(true)]
     [Browsable(true)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]

--- a/source/IPAddressControl.cs
+++ b/source/IPAddressControl.cs
@@ -178,6 +178,22 @@ namespace IPAddressControlLib
       }
     }
 
+    [Browsable(false)]
+    public int FocusedFieldIndex
+    {
+      get
+      {
+        for (var i = 0; i < _fieldControls.Length; i++)
+        {
+          if (_fieldControls[i].Focused)
+          {
+            return i;
+          }
+        }
+        return -1;
+      }
+    }
+
     [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IPAddress IPAddress
     {

--- a/source/IPAddressControl.cs
+++ b/source/IPAddressControl.cs
@@ -627,20 +627,25 @@ namespace IPAddressControlLib
 
     private void Cleanup()
     {
-      foreach (DotControl dc in _dotControls)
+      if (_dotControls != null)
       {
-        Controls.Remove(dc);
-        dc.Dispose();
+        foreach (DotControl dc in _dotControls)
+        {
+          Controls.Remove(dc);
+          dc.Dispose();
+        }
+        _dotControls = null;
       }
 
-      foreach (FieldControl fc in _fieldControls)
+      if (_fieldControls != null)
       {
-        Controls.Remove(fc);
-        fc.Dispose();
+        foreach (FieldControl fc in _fieldControls)
+        {
+          Controls.Remove(fc);
+          fc.Dispose();
+        }
+        _fieldControls = null;
       }
-
-      _dotControls = null;
-      _fieldControls = null;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1806", Justification = "What should be done if ReleaseDC() doesn't work?")]


### PR DESCRIPTION
Hi, This pull request contains a simple fix to the Cleanup method to prevent a NullReferenceException occurring in the VS Designer.

I have also implemented two additional read-only properties that I needed in order to discover the location of the I beam cursor within the control; allowing me to implement navigation between controls using keyboard arrow keys.

.SelectionStart == 0 // Cursor is in the first field and to the left of any text
.FocusedFieldIndex == 3 && .SelectionStart == .Text.Length // Cursor is in the last field and to the right of any text.