### PR TITLE
Added NuGet Shield to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![NuGet](https://img.shields.io/nuget/v/IPAddressControlLib)](https://www.nuget.org/packages/IPAddressControlLib)
+
 # ipaddresscontrollib
 
 ![alt IPAddressControl in use](https://raw.githubusercontent.com/m66n/m66n.github.io/master/img/ipaddresscontrollib/TestIPAddressControl.png)


### PR DESCRIPTION
Found the NuGet and felt it was too hard to find from the GitHub page.
Here: https://www.nuget.org/packages/IPAddressControlLib

Shield information found here: https://shields.io/category/version

I don't know why it is currently showing "Package Not Found". I have used this shield on many other projects, this is the first time I see it. Maybe it is because there is no actual version released in the NuGet? It should fix itself if a NuGet version is released.